### PR TITLE
Don't poll konserve for empty objects.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,7 @@
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [aleph "0.4.6"]
-                 ; if you want to use filestore, look here: https://github.com/replikativ/konserve/pull/27
-                 ; memory store works fine with 0.5.0
-                 ;[io.replikativ/konserve "0.6.0-SNAPSHOT"]
-                 [io.replikativ/konserve "0.5.0"]
+                 [io.replikativ/konserve "0.5.1"]
                  [io.replikativ/superv.async "0.2.9"]
                  [com.arohner/uri "0.1.2"]
                  [org.clojure/data.xml "0.2.0-alpha6"]]


### PR DESCRIPTION
I think konserve-leveldb might not actually store empty values? Or somehow the value comes out as nil when read, and konserve-leveldb doesn't call our callback if the value it read is nil.

Anyway just short-circuit konserve altogether if we are reading an empty object.